### PR TITLE
Fixed FusionFurnaceRecipeWrapper to read metadata and nbt

### DIFF
--- a/src/main/java/alexndr/plugins/Fusion/modsupport/jei/FusionFurnaceRecipeWrapper.java
+++ b/src/main/java/alexndr/plugins/Fusion/modsupport/jei/FusionFurnaceRecipeWrapper.java
@@ -26,22 +26,19 @@ public class FusionFurnaceRecipeWrapper implements IRecipeWrapper
             this.catalyst = stackHelper.toItemStackList(recipe.catalyst.getOre());
         }
         else {
-            this.catalyst = stackHelper.toItemStackList(new ItemStack(recipe.catalyst.getItem(), 
-                                                                 recipe.catalyst.getAmount()));
+            this.catalyst = new ArrayList<ItemStack>(recipe.catalyst.itemsList());
         }
         if (recipe.input1 instanceof DictMaterial) {
             this.input1 = stackHelper.toItemStackList(recipe.input1.getOre());
         }
         else {
-            this.input1 = stackHelper.toItemStackList(new ItemStack(recipe.input1.getItem(), 
-                                                                 recipe.input1.getAmount()));
+        	this.input1 = new ArrayList<ItemStack>(recipe.catalyst.itemsList());
         }
         if (recipe.input2 instanceof DictMaterial) {
             this.input2 = stackHelper.toItemStackList(recipe.input2.getOre());
         }
         else {
-            this.input2 = stackHelper.toItemStackList(new ItemStack(recipe.input2.getItem(), 
-                                                                 recipe.input2.getAmount()));
+        	this.input2 = new ArrayList<ItemStack>(recipe.catalyst.itemsList());
         }
         
     } // end ctor


### PR DESCRIPTION
previously I incorrectly asumed the recipie wrapper ingredients were stored as ItemStacks, however even being stored as FusionMaterial instances, a fix to read nbt and metadata is pretty straightforward.